### PR TITLE
Offline support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 state.json
 __pycache__/
+firmware/

--- a/README.md
+++ b/README.md
@@ -30,3 +30,10 @@ This guide assumes you're running a Raspberry Pi (< 4) with PiTFT and have follo
 Also included is a script to create a systemd service to start the flasher on boot. To use it, run `./create-systemd-service.sh` and it will start on next boot. To stop it from starting on boot, run `sudo systemctl disable gp2040-flasher`. If you want to start it manually, run `sudo systemctl start gp2040-flasher`.
 
 You can double press the bottom button to exit the program. Note if you installed the systemd service, it will restart the program.
+
+## Offline Usage
+
+1. Download the latest releases from the [releases page](https://github.com/OpenStickCommunity/GP2040-CE/releases) and place them in the `firmware` directory.
+2. Start the app with `sudo python3 main.py --offline`.
+
+The app will also fail gracefully if you're API rate limited or any other connection issue to GitHub and fallback to offline mode.

--- a/github.py
+++ b/github.py
@@ -1,6 +1,5 @@
 import requests
 import urllib.request
-import tempfile
 import os
 
 
@@ -12,8 +11,11 @@ class Github:
 
     def get_latest_release_info(self):
         url = f"https://api.github.com/repos/{self.owner}/{self.repo}/releases"
-        response = requests.get(url)
-        if response.status_code == 200:
+
+        try:
+            response = requests.get(url)
+            response.raise_for_status()  # Raise exception for non-2xx status codes
+
             releases = response.json()
             for release in releases:
                 if not release.get("prerelease"):
@@ -25,11 +27,10 @@ class Github:
                         asset for asset in assets if asset["name"] != "flash_nuke.uf2"]
 
                     return version, release_date, assets
-        else:
-            # Handle API request error
-            print("Error:", response.status_code)
+        except requests.exceptions.RequestException as e:
+            print("Failed to fetch release info:", e)
 
-            return None, None, None
+        return None, None, None
 
     def download_file(self, url):
         # Extract the filename from the URL


### PR DESCRIPTION
Gracefully fails GitHub API requests and allows a choice from locally saved firmware instead.
You can also launch with --offline to force this mode and never connect to GitHub API.